### PR TITLE
Issue #63: Added URL detection for video and pulled title from course material

### DIFF
--- a/web/forms.py
+++ b/web/forms.py
@@ -331,6 +331,7 @@ class CourseMaterialForm(forms.ModelForm):
             "description",
             "material_type",
             "file",
+            "external_url",
             "session",
             "is_downloadable",
             "order",
@@ -340,9 +341,13 @@ class CourseMaterialForm(forms.ModelForm):
             "description": TailwindTextarea(attrs={"rows": 3}),
             "material_type": TailwindSelect(),
             "file": TailwindFileInput(),
+            "external_url": TailwindInput(attrs={"placeholder": "Enter video URL"}),  # Add widget for external_url
             "session": TailwindSelect(),
             "is_downloadable": TailwindCheckboxInput(),
             "order": TailwindNumberInput(attrs={"min": 0}),
+        }
+        labels = {
+            "external_url": "External URL",  # Update label
         }
 
     def __init__(self, *args, course=None, **kwargs):

--- a/web/templates/courses/upload_material.html
+++ b/web/templates/courses/upload_material.html
@@ -17,6 +17,9 @@
             <div>
               <label for="{{ field.id_for_label }}" class="block text-sm font-medium mb-2">{{ field.label }}</label>
               {{ field }}
+              {% if field.name == "external_url" %}
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">If this is a video URL, the title will be auto-detected.</p>
+              {% endif %}
               {% if field.help_text %}
                 <small class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ field.help_text }}</small>
               {% endif %}
@@ -37,4 +40,26 @@
       </div>
     </div>
   </div>
+  <script>
+      document.addEventListener("DOMContentLoaded", function() {
+          const externalUrlField = document.getElementById("id_external_url");
+          const titleField = document.getElementById("id_title");
+
+          externalUrlField.addEventListener("change", function() {
+              const url = externalUrlField.value;
+              if (url) {
+                  fetch(`/fetch-video-title/?url=${encodeURIComponent(url)}`)
+                      .then(response => response.json())
+                      .then(data => {
+                          if (data.title) {
+                              titleField.value = data.title;
+                          }
+                      })
+                      .catch(error => console.error("Error fetching video title:", error));
+              } else {
+                  titleField.value = "";
+              }
+          });
+      });
+  </script>
 {% endblock content %}

--- a/web/urls.py
+++ b/web/urls.py
@@ -166,6 +166,7 @@ urlpatterns += i18n_patterns(
     path("challenges/<int:week_number>/", views.challenge_detail, name="challenge_detail"),
     path("challenges/<int:week_number>/submit/", views.challenge_submit, name="challenge_submit"),
     path("current-weekly-challenge/", views.current_weekly_challenge, name="current_weekly_challenge"),
+    path("fetch-video-title/", views.fetch_video_title, name="fetch_video_title"),
     prefix_default_language=True,
 )
 

--- a/web/views.py
+++ b/web/views.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 
 import requests
 import stripe
+from bs4 import BeautifulSoup
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model, login
@@ -2617,3 +2618,20 @@ def challenge_submit(request, week_number):
         form = ChallengeSubmissionForm()
 
     return render(request, "web/challenge_submit.html", {"challenge": challenge, "form": form})
+
+
+@require_GET
+def fetch_video_title(request):
+    url = request.GET.get("url")
+    if not url:
+        return JsonResponse({"error": "URL parameter is required"}, status=400)
+
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.content, "html.parser")
+        title_tag = soup.find("title")
+        title = title_tag.string if title_tag else "Untitled Video"
+        return JsonResponse({"title": title})
+    except requests.RequestException:
+        return JsonResponse({"error": "Failed to fetch video title"}, status=500)


### PR DESCRIPTION
This pull request resolves issue #63 by implementing functionality to add an external URL to course materials and automatically detect the title of a video if the provided URL points to a video platform.

#### Changes:
- **Forms:**
  - Added a new `external_url` field to the `CourseMaterialForm` for URL input.
  - Updated the form widget for `external_url` to include a placeholder and improve user experience.
  - Added a label for the `external_url` field to ensure clarity.

- **Templates:**
  - Modified `upload_material.html` to display a message indicating that the video title will be auto-detected when a URL is provided.
  - Included a JavaScript snippet that listens for changes to the `external_url` field, fetching the video title from the URL and auto-populating the title field.

- **Views:**
  - Implemented a `fetch_video_title` view that uses `requests` and `BeautifulSoup` to fetch and parse the page title from the provided URL, which is then used to auto-populate the `title` field.

- **URLs:**
  - Added a new URL route `fetch-video-title/` to handle the request for fetching video titles from external URLs.

#### How It Works:
- When a user enters a video URL in the `external_url` field, the system sends a request to the `/fetch-video-title/` endpoint to extract the video title.
- The extracted title is automatically populated into the `title` field of the course material form.

This enhancement improves the user experience by eliminating the need for manual title input when adding video URLs to course materials.

#### Testing:
- Ensure the `external_url` field is added correctly to the form and displays properly in the UI.
- Test by entering a valid video URL (e.g., from YouTube) and verify that the title is auto-populated.
- Test edge cases such as invalid URLs to ensure proper error handling.

Closes #63.

https://github.com/user-attachments/assets/93b66686-1c6b-4d84-88bc-e497fd3542f7
